### PR TITLE
Bubble size responds to cost knob

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -136,7 +136,7 @@ export default function CarefulnessKnob() {
                     dataKey="z"
                     name="Cost"
                     domain={[1, 10]}
-                    range={[60, 400]}
+                    range={[60, 3000]}
                   />
                   <Scatter
                     name="Data Point"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -131,7 +131,13 @@ export default function CarefulnessKnob() {
                       style: { textAnchor: "middle", fontSize: "14px", fill: "#475569" },
                     }}
                   />
-                  <ZAxis type="number" dataKey="z" range={[60, 400]} name="Cost" />
+                  <ZAxis
+                    type="number"
+                    dataKey="z"
+                    name="Cost"
+                    domain={[1, 10]}
+                    range={[60, 400]}
+                  />
                   <Scatter
                     name="Data Point"
                     data={data}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -136,7 +136,7 @@ export default function CarefulnessKnob() {
                     dataKey="z"
                     name="Cost"
                     domain={[1, 10]}
-                    range={[60, 5000]}
+                    range={[60, 10000]}
                   />
                   <Scatter
                     name="Data Point"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -136,7 +136,7 @@ export default function CarefulnessKnob() {
                     dataKey="z"
                     name="Cost"
                     domain={[1, 10]}
-                    range={[60, 3000]}
+                    range={[60, 5000]}
                   />
                   <Scatter
                     name="Data Point"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useCallback } from "react"
-import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, ResponsiveContainer } from "recharts"
+import { ScatterChart, Scatter, XAxis, YAxis, ZAxis, CartesianGrid, ResponsiveContainer } from "recharts"
 import { Card, CardContent } from "@/components/ui/card"
 import { RotatingKnob } from "@/components/rotating-knob"
 
@@ -62,7 +62,7 @@ export default function CarefulnessKnob() {
     {
       x: time,
       y: carefulness,
-      z: cost * 100 + 200, // Increased scaling for more visible size changes
+      z: cost, // bubble size driven directly by cost
     },
   ]
 
@@ -131,6 +131,7 @@ export default function CarefulnessKnob() {
                       style: { textAnchor: "middle", fontSize: "14px", fill: "#475569" },
                     }}
                   />
+                  <ZAxis type="number" dataKey="z" range={[60, 400]} name="Cost" />
                   <Scatter
                     name="Data Point"
                     data={data}


### PR DESCRIPTION
## Summary
- use `ZAxis` from Recharts so scatter bubbles can scale
- base bubble size directly on cost value

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c7c3cf3c4832a962024af06f0927c